### PR TITLE
Suggest changing https to default to "true"

### DIFF
--- a/ansible_templates/code.jinja
+++ b/ansible_templates/code.jinja
@@ -140,7 +140,7 @@ def main():
         "username": {"required": True, "type": "str"},
         "password": {"required": False, "type": "str", "no_log": True},
         "vdom": {"required": False, "type": "str", "default": "root"},
-        "https": {"required": False, "type": "bool", "default": "False"},
+        "https": {"required": False, "type": "bool", "default": True},
         "{{path}}_{{name}}": {
             "required": False, "type": "dict",
             "options": {


### PR DESCRIPTION
By default, applying a license to a FGT appliance will enable HTTPS, therefore in most situations, unless you're *only* working with an eval license, this will "normally" be true.